### PR TITLE
Services: Add state reconciliation & update mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	git.fd.io/govpp.git v0.3.4
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/calico-vpp/vpplink v0.0.0-20200504131935-5e0d06b0edec
+	github.com/calico-vpp/vpplink v0.0.0-20200504154254-1ac1d38fc9f6
 	github.com/containernetworking/plugins v0.8.2
 	github.com/coreos/etcd v3.3.17+incompatible
 	github.com/dgryski/go-farm v0.0.0-20191112170834-c2139c5d712b // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/calico-vpp/vpplink v0.0.0-20200428123446-9bf599b35164 h1:Ef25ofThhJw2
 github.com/calico-vpp/vpplink v0.0.0-20200428123446-9bf599b35164/go.mod h1:XTN1gO6hiGU5wsrufaFMODcu4Puaief2iRsj+V/iIYY=
 github.com/calico-vpp/vpplink v0.0.0-20200504131935-5e0d06b0edec h1:xlavfPRE0CmMYzaNPVEu2Pku+EBp56s2xZWhK3WldbM=
 github.com/calico-vpp/vpplink v0.0.0-20200504131935-5e0d06b0edec/go.mod h1:XTN1gO6hiGU5wsrufaFMODcu4Puaief2iRsj+V/iIYY=
+github.com/calico-vpp/vpplink v0.0.0-20200504154254-1ac1d38fc9f6 h1:bJYabZaqLsMUqKh4DNaLXyqioi92NDRZrIN385puavk=
+github.com/calico-vpp/vpplink v0.0.0-20200504154254-1ac1d38fc9f6/go.mod h1:XTN1gO6hiGU5wsrufaFMODcu4Puaief2iRsj+V/iIYY=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/prettybench v0.0.0-20150116022406-03b8cfe5406c/go.mod h1:Xe6ZsFhtM8HrDku0pxJ3/Lr51rwykrzgFwpmTzleatY=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/services/services.go
+++ b/services/services.go
@@ -43,6 +43,8 @@ type ServiceProvider interface {
 	Init() error
 	AddNodePort(service *v1.Service, ep *v1.Endpoints) error
 	DelNodePort(service *v1.Service, ep *v1.Endpoints) error
+	UpdateNodePort(service *v1.Service, ep *v1.Endpoints) error
+	UpdateClusterIP(service *v1.Service, ep *v1.Endpoints) error
 	AddClusterIP(service *v1.Service, ep *v1.Endpoints) error
 	DelClusterIP(service *v1.Service, ep *v1.Endpoints) error
 	AnnounceLocalAddress(addr *net.IPNet, isWithdrawal bool) error
@@ -253,11 +255,12 @@ func (s *Server) endpointModified(ep *v1.Endpoints, old *v1.Endpoints) error {
 		return nil
 	}
 	s.log.Debugf("Found matching service")
-	err := s.DelServiceNat(service, old)
-	if err != nil {
-		s.log.Errorf("Deleting NAT config failed, trying to re-add anyway")
-	}
-	return s.AddServiceNat(service, ep)
+	return s.UpdateServiceNat(service, ep)
+	// err := s.DelServiceNat(service, old)
+	// if err != nil {
+	// 	s.log.Errorf("Deleting NAT config failed, trying to re-add anyway")
+	// }
+	// return s.AddServiceNat(service, ep)
 }
 
 func (s *Server) endpointRemoved(ep *v1.Endpoints) error {
@@ -290,11 +293,7 @@ func (s *Server) serviceModified(service *v1.Service, old *v1.Service) error {
 		return nil
 	}
 	s.log.Debugf("Found matching endpoint")
-	err := s.DelServiceNat(old, ep)
-	if err != nil {
-		s.log.Errorf("Deleting NAT config failed, trying to re-add anyway : %+v", err)
-	}
-	return s.AddServiceNat(service, ep)
+	return s.UpdateServiceNat(old, ep)
 }
 
 func (s *Server) serviceRemoved(service *v1.Service) error {


### PR DESCRIPTION
Deleting vpp NAT/LB entries breaks long lasting
connections. And calico polling generates recurrent
update calls. So we have to maintain state & only
do add/dels when needed.
This currently only works for nat44

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>